### PR TITLE
chore: update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/testing-sub-issue.md
+++ b/.github/ISSUE_TEMPLATE/testing-sub-issue.md
@@ -1,0 +1,27 @@
+---
+name: Testing Sub-Issue
+about: Create a Testing sub-issue linked to a PR, to track validation and demo readiness.
+title: 'Testing: [PR Title Here]'
+labels: testing
+assignees: ''
+
+---
+
+Testing: [PR Title Here]
+
+### Parent PR
+Link to the PR this Testing issue belongs to:  
+`<insert PR link here>`
+
+---
+
+### Scope
+This issue tracks **testing tasks** for the PR to ensure correctness and demo readiness.
+
+---
+
+### Suggested Checklist (edit as needed)
+- [ ] Verify feature works as described in the PR  
+- [ ] Validate permissions / access rules  
+- [ ] Run automated tests and confirm they pass  
+- [ ] Test edge cases or unusual inputs


### PR DESCRIPTION
Added a new Testing issue template under .github/ISSUE_TEMPLATE.
This template will be used to create sub-issues for PR testing inside the Code Review workflow.

- Provides a default title placeholder
- Includes short description and checklist (can be edited for specific features)
- Adds clarity to testing tasks linked to PRs