### PR TITLE
P2: Fix ( .github/workflows/test.yaml ): Update Redis CI image to redis:8

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,7 +27,7 @@ jobs:
 
     services:
       redis:
-        image: 'redis:8.0.1'
+        image: 'redis:8'
         # Set health checks to wait until redis has started
         options: >-
           --health-cmd "redis-cli ping"


### PR DESCRIPTION
# PR: chore/redis-ci — Update Redis tag in GitHub Actions to redis:8

---

## Full Path to Modified File(s)
- `.github/workflows/test.yaml`

---

## Problem
During GitHub Actions test runs, the step that starts Redis fails with the following error:
<img width="1422" height="878" alt="Screenshot 2025-09-24 at 8 37 01 PM" src="https://github.com/user-attachments/assets/1c8d2f35-b481-428e-b2d8-9f6b53492969" />

This issue began after I created a PR for my feature branch (`feature/search_backend`), but it is **not caused by my feature code**.  
It is due to Docker Hub no longer allowing pulls from the `redis:8.0.1` image without authentication.

---

## Solution
- Updated the GitHub Actions workflow to pull **`redis:8`** instead of `redis:8.0.1`.  
- `redis:8` is the latest stable tag for Redis 8 and is publicly available.  
- This resolves the authentication error while maintaining a consistent test environment.

---

## Why Separate PR?
This fix is unrelated to the search feature work. Keeping it in its own branch (`fix/redis-ci`) ensures a **clean, minimal change** to CI/infra only.


